### PR TITLE
Updated height, width and size.

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -10,7 +10,6 @@ For advertisers and agencies using AdForm, use [AdForms specifications](http://t
 * Banner: always 100% width of is content container, but has fixed height.
   * Currently available formats:
     * Height: 225px, Width: 100%
-* Box: a square where the proportions between width and height always are equal but the dimensions varies.
 
 ### Size
 * Max 100 kb in compressed state (all files compressed/zipped together).


### PR DESCRIPTION
Rather than specifying dimensions for ads at this early stage, I would like to suggest two approaches that can help define dimensions at a later stage.

Also, suggesting that resources loaded after a user interaction (e.g. click) not count against the total size of the ad (e.g. video, audio or image). 
