### PR TITLE
Added a few links to videos that prove a few claims

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -28,7 +28,7 @@ Note: The size limitation is on the initial load. You can lazy load additional c
 * [Maximum of two HTTP requests to JavaScript libraries (at least one to CDN).](spec/maximumhttprequests.md)
 * Animation _prior to a user interaction_ must be written using [CSS3 Transitions, Transforms and/or Animation](spec/cssforanimations.md)
  * [JavaScript animations are forbidden before an user interaction](spec/jsanimations.md).
- * You can not use of _requestAnimationFrame_ as it break features in the host document.
+ * You can not use of _requestAnimationFrame_ as [it break features in the host document](http://youtu.be/cgcue5_--SY).
 * References to resources must start with http:// or https:// , not only //. Because of limitations in our delivery system.
 * You can not override default touch events.
 * You can not use `touchstart` as an alias for `click`.

--- a/tips.md
+++ b/tips.md
@@ -10,6 +10,7 @@
 # Tips for improved performance
 
 * Keep the number of HTTP requests to a minimum
+* Compress images as much as possible without visible image noise. [PNG](http://youtu.be/cqNTCf6oCJ8) VS [JPEG](http://youtu.be/w655JPmzpUI)
 * On the initial load only use JavaScript to add event listeners
 * Load the scripts last, so text and images show up while scripts are loading
 * When using Web Fonts keep in mind that users might not download the font because of bandwith issues, so make sure the fallback looks good


### PR DESCRIPTION
I've made a few videos to show the problems with requestAnimationFrame on iOS, and difference in load time between PNG/JPEG. Uploaded them to Youtube and added links where relevant.
