### PR TITLE
Remove requestAnimationFrame limitation

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -27,7 +27,6 @@ Note: The size limitation is on the initial load. You can lazy load additional c
 * [Maximum of two HTTP requests to JavaScript libraries (at least one to CDN).](spec/maximumhttprequests.md)
 * Animation _prior to a user interaction_ must be written using [CSS3 Transitions, Transforms and/or Animation](spec/cssforanimations.md)
  * [JavaScript animations are forbidden before an user interaction](spec/jsanimations.md).
- * You can not use of _requestAnimationFrame_ as [it break features in the host document](http://youtu.be/cgcue5_--SY).
 * References to resources must be absolute and start with http:// or https:// , not only //. Because of limitations in our delivery system.
 * Only use `event.preventDefault` or `event.stopPropagation` for touch-events moving horizontally +/- 30°.
 * Do not use `touchstart` as an alias for `click`. Because `touchstart` is fired when the user is scrolling.


### PR DESCRIPTION
iOS 6.0 represents a very small percentage of our users now (0.06% on FINN at least) so this limitation should be removed.